### PR TITLE
Add django-tables2 to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Django==1.11.11
 django-environ==0.4.4
 django-debug-toolbar==1.9.1
 stripe==1.79.1
+django-tables2==1.21.2


### PR DESCRIPTION
## 目的
`python manage.py runserver` 実行時に `ModuleNotFoundError: No module named 'django_tables2'` が発生したので修正

## 内容
`requirements.txt` に `django_tables2` を追加